### PR TITLE
feat: surface version prereqs and skip privileged steps locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ $ detest run --job test --only-step "Lint" --format json
 
 # Stream command output as it runs
 $ detest run --verbose
-\n+# Allow privileged commands (e.g., sudo/apt-get) when absolutely necessary
+
+# Allow privileged commands (e.g., sudo/apt-get) when absolutely necessary
 $ DETEST_ALLOW_PRIVILEGED=1 detest run
 ```
 
@@ -50,6 +51,9 @@ verbose: false
 format: pretty             # pretty|json
 warn:
   version_mismatch: true   # warn when local Ruby/Node major.minor differs
+privileged_command_patterns:
+  - (?i)^sudo\b
+  - (?i)\bapt-get\b
 ```
 
 ## Current Status

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $ detest run --job test --only-step "Lint" --format json
 
 # Stream command output as it runs
 $ detest run --verbose
+\n+# Allow privileged commands (e.g., sudo/apt-get) when absolutely necessary
+$ DETEST_ALLOW_PRIVILEGED=1 detest run
 ```
 
 Flags such as `--workflow`, `--job`, `--only-step`, and `--skip-step` accept multiple values and support substring or `/regex/` matches. When no workflows are provided, Detest automatically loads `.github/workflows/*.yml`/`*.yaml` in lexicographic order. Execution stops with a non-zero exit code if any step fails, but all remaining steps continue to run so you see the full picture.
@@ -47,7 +49,7 @@ dry_run: false
 verbose: false
 format: pretty             # pretty|json
 warn:
-  version_mismatch: false  # reserved for future version checks
+  version_mismatch: true   # warn when local Ruby/Node major.minor differs
 ```
 
 ## Current Status
@@ -56,6 +58,7 @@ warn:
 - ✅ Sequential execution with env/shell/working-directory resolution
 - ✅ Pretty & JSON reporters with per-step duration/excerpts
 - ✅ Dry-run, verbose streaming, job/step filters, repeatable `--workflow`
-- 🚧 Upcoming: cross-language version warnings, additional CI providers, matrix & services support
+- 🚧 Upcoming: richer runtime pre-flight checks, additional CI providers, matrix & services support
+  - Version mismatch warnings are enabled by default; set `warn.version_mismatch: false` to silence them.
 
 Want to dig in? Run `go test ./...` to exercise the parser, runner, and CLI tests.

--- a/cmd/detest/pipeline.go
+++ b/cmd/detest/pipeline.go
@@ -1,21 +1,25 @@
 package main
 
 import (
-	"errors"
-	"fmt"
+    "errors"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
 
-	"github.com/bgricker/detest/internal/config"
-	"github.com/bgricker/detest/internal/discovery"
-	"github.com/bgricker/detest/internal/provider"
-	"github.com/bgricker/detest/internal/provider/filter"
-	githubprovider "github.com/bgricker/detest/internal/provider/github"
+    "github.com/bgricker/detest/internal/config"
+    "github.com/bgricker/detest/internal/discovery"
+    "github.com/bgricker/detest/internal/provider"
+    "github.com/bgricker/detest/internal/provider/filter"
+    githubprovider "github.com/bgricker/detest/internal/provider/github"
+    "github.com/bgricker/detest/internal/version"
 )
 
 // pipelineData bundles parsed workflows with warnings and metadata.
 type pipelineData struct {
-	provider  string
-	workflows []provider.Workflow
-	warnings  []provider.Warning
+    provider  string
+    workflows []provider.Workflow
+    warnings  []provider.Warning
 }
 
 func loadPipeline(root string, cfg config.Config) (pipelineData, error) {
@@ -39,12 +43,14 @@ func loadPipeline(root string, cfg config.Config) (pipelineData, error) {
 
 	switch providerName {
 	case config.ProviderGitHub:
-		parser := githubprovider.NewParser(root)
-		pipeline, err := parser.Parse(paths)
-		if err != nil {
-			return pipelineData{}, err
-		}
-		return pipelineData{provider: providerName, workflows: pipeline.Workflows, warnings: pipeline.Warnings}, nil
+        parser := githubprovider.NewParser(root)
+        pipeline, err := parser.Parse(paths)
+        if err != nil {
+            return pipelineData{}, err
+        }
+        versionWarnings := detectVersionWarnings(root, cfg)
+        warnings := append(pipeline.Warnings, versionWarnings...)
+        return pipelineData{provider: providerName, workflows: pipeline.Workflows, warnings: warnings}, nil
 	default:
 		return pipelineData{}, fmt.Errorf("provider %q not implemented", providerName)
 	}
@@ -66,4 +72,51 @@ func applyFilters(data pipelineData, cfg config.Config) (pipelineData, error) {
 
 	filtered := filter.FilterWorkflows(data.workflows, jobPatterns, onlyPatterns, skipPatterns)
 	return pipelineData{provider: data.provider, workflows: filtered, warnings: data.warnings}, nil
+}
+
+func detectVersionWarnings(root string, cfg config.Config) []provider.Warning {
+    if !cfg.Warn.VersionMismatch {
+        return nil
+    }
+
+    var warnings []provider.Warning
+
+    rubyPath := filepath.Join(root, ".ruby-version")
+    if contents, err := os.ReadFile(rubyPath); err == nil {
+        required := strings.TrimSpace(string(contents))
+        if required != "" {
+            info, detectErr := version.DetectRuby()
+            warn := buildVersionWarning("ruby", required, info.Version, detectErr)
+            if warn != "" {
+                warnings = append(warnings, provider.Warning{Workflow: ".ruby-version", Message: warn})
+            }
+        }
+    }
+
+    nodePath := filepath.Join(root, ".node-version")
+    if contents, err := os.ReadFile(nodePath); err == nil {
+        required := strings.TrimSpace(string(contents))
+        if required != "" {
+            info, detectErr := version.DetectNode()
+            warn := buildVersionWarning("node", required, info.Version, detectErr)
+            if warn != "" {
+                warnings = append(warnings, provider.Warning{Workflow: ".node-version", Message: warn})
+            }
+        }
+    }
+
+    return warnings
+}
+
+func buildVersionWarning(name, required, actual string, detectErr error) string {
+    if detectErr != nil {
+        if version.Missing(detectErr) {
+            return fmt.Sprintf("%s executable not found; required %s", name, required)
+        }
+        return fmt.Sprintf("unable to detect %s version: %v", name, detectErr)
+    }
+    if !version.CompareMajorMinor(required, actual) {
+        return fmt.Sprintf("%s version mismatch: required %s (from .%s-version) but found %s", name, required, name, actual)
+    }
+    return ""
 }

--- a/cmd/detest/pipeline.go
+++ b/cmd/detest/pipeline.go
@@ -1,25 +1,25 @@
 package main
 
 import (
-    "errors"
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/bgricker/detest/internal/config"
-    "github.com/bgricker/detest/internal/discovery"
-    "github.com/bgricker/detest/internal/provider"
-    "github.com/bgricker/detest/internal/provider/filter"
-    githubprovider "github.com/bgricker/detest/internal/provider/github"
-    "github.com/bgricker/detest/internal/version"
+	"github.com/bgricker/detest/internal/config"
+	"github.com/bgricker/detest/internal/discovery"
+	"github.com/bgricker/detest/internal/provider"
+	"github.com/bgricker/detest/internal/provider/filter"
+	githubprovider "github.com/bgricker/detest/internal/provider/github"
+	"github.com/bgricker/detest/internal/version"
 )
 
 // pipelineData bundles parsed workflows with warnings and metadata.
 type pipelineData struct {
-    provider  string
-    workflows []provider.Workflow
-    warnings  []provider.Warning
+	provider  string
+	workflows []provider.Workflow
+	warnings  []provider.Warning
 }
 
 func loadPipeline(root string, cfg config.Config) (pipelineData, error) {
@@ -43,14 +43,14 @@ func loadPipeline(root string, cfg config.Config) (pipelineData, error) {
 
 	switch providerName {
 	case config.ProviderGitHub:
-        parser := githubprovider.NewParser(root)
-        pipeline, err := parser.Parse(paths)
-        if err != nil {
-            return pipelineData{}, err
-        }
-        versionWarnings := detectVersionWarnings(root, cfg)
-        warnings := append(pipeline.Warnings, versionWarnings...)
-        return pipelineData{provider: providerName, workflows: pipeline.Workflows, warnings: warnings}, nil
+		parser := githubprovider.NewParser(root)
+		pipeline, err := parser.Parse(paths)
+		if err != nil {
+			return pipelineData{}, err
+		}
+		versionWarnings := detectVersionWarnings(root, cfg)
+		warnings := append(pipeline.Warnings, versionWarnings...)
+		return pipelineData{provider: providerName, workflows: pipeline.Workflows, warnings: warnings}, nil
 	default:
 		return pipelineData{}, fmt.Errorf("provider %q not implemented", providerName)
 	}
@@ -75,48 +75,48 @@ func applyFilters(data pipelineData, cfg config.Config) (pipelineData, error) {
 }
 
 func detectVersionWarnings(root string, cfg config.Config) []provider.Warning {
-    if !cfg.Warn.VersionMismatch {
-        return nil
-    }
+	if !cfg.Warn.VersionMismatch {
+		return nil
+	}
 
-    var warnings []provider.Warning
+	var warnings []provider.Warning
 
-    rubyPath := filepath.Join(root, ".ruby-version")
-    if contents, err := os.ReadFile(rubyPath); err == nil {
-        required := strings.TrimSpace(string(contents))
-        if required != "" {
-            info, detectErr := version.DetectRuby()
-            warn := buildVersionWarning("ruby", required, info.Version, detectErr)
-            if warn != "" {
-                warnings = append(warnings, provider.Warning{Workflow: ".ruby-version", Message: warn})
-            }
-        }
-    }
+	rubyPath := filepath.Join(root, ".ruby-version")
+	if contents, err := os.ReadFile(rubyPath); err == nil {
+		required := strings.TrimSpace(string(contents))
+		if required != "" {
+			info, detectErr := version.DetectRuby()
+			warn := buildVersionWarning("ruby", required, info.Version, detectErr)
+			if warn != "" {
+				warnings = append(warnings, provider.Warning{Workflow: ".ruby-version", Message: warn})
+			}
+		}
+	}
 
-    nodePath := filepath.Join(root, ".node-version")
-    if contents, err := os.ReadFile(nodePath); err == nil {
-        required := strings.TrimSpace(string(contents))
-        if required != "" {
-            info, detectErr := version.DetectNode()
-            warn := buildVersionWarning("node", required, info.Version, detectErr)
-            if warn != "" {
-                warnings = append(warnings, provider.Warning{Workflow: ".node-version", Message: warn})
-            }
-        }
-    }
+	nodePath := filepath.Join(root, ".node-version")
+	if contents, err := os.ReadFile(nodePath); err == nil {
+		required := strings.TrimSpace(string(contents))
+		if required != "" {
+			info, detectErr := version.DetectNode()
+			warn := buildVersionWarning("node", required, info.Version, detectErr)
+			if warn != "" {
+				warnings = append(warnings, provider.Warning{Workflow: ".node-version", Message: warn})
+			}
+		}
+	}
 
-    return warnings
+	return warnings
 }
 
 func buildVersionWarning(name, required, actual string, detectErr error) string {
-    if detectErr != nil {
-        if version.Missing(detectErr) {
-            return fmt.Sprintf("%s executable not found; required %s", name, required)
-        }
-        return fmt.Sprintf("unable to detect %s version: %v", name, detectErr)
-    }
-    if !version.CompareMajorMinor(required, actual) {
-        return fmt.Sprintf("%s version mismatch: required %s (from .%s-version) but found %s", name, required, name, actual)
-    }
-    return ""
+	if detectErr != nil {
+		if version.Missing(detectErr) {
+			return fmt.Sprintf("%s executable not found; required %s", name, required)
+		}
+		return fmt.Sprintf("unable to detect %s version: %v", name, detectErr)
+	}
+	if !version.CompareMajorMinor(required, actual) {
+		return fmt.Sprintf("%s version mismatch: required %s (from .%s-version) but found %s", name, required, name, actual)
+	}
+	return ""
 }

--- a/cmd/detest/run.go
+++ b/cmd/detest/run.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"fmt"
-	"strings"
+    "fmt"
+    "os"
+    "strings"
 
-	"github.com/bgricker/detest/internal/config"
-	"github.com/bgricker/detest/internal/output"
-	"github.com/bgricker/detest/internal/runner"
-	"github.com/spf13/cobra"
+    "github.com/bgricker/detest/internal/config"
+    "github.com/bgricker/detest/internal/output"
+    "github.com/bgricker/detest/internal/runner"
+    "github.com/spf13/cobra"
 )
 
 func newRunCmd() *cobra.Command {
@@ -34,14 +35,17 @@ func runExecute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	runOpts := runner.Options{
-		Root:      root,
-		Stdout:    cmd.OutOrStdout(),
-		Stderr:    cmd.ErrOrStderr(),
-		Verbose:   cfg.Verbose,
-		DryRun:    cfg.DryRun,
-		TailLines: 20,
-	}
+    allowPrivileged := os.Getenv("DETEST_ALLOW_PRIVILEGED") == "1"
+
+    runOpts := runner.Options{
+        Root:      root,
+        Stdout:    cmd.OutOrStdout(),
+        Stderr:    cmd.ErrOrStderr(),
+        Verbose:   cfg.Verbose,
+        DryRun:    cfg.DryRun,
+        TailLines: 20,
+        AllowPrivileged: allowPrivileged,
+    }
 	execRunner := runner.New(runOpts)
 	results, summary, err := execRunner.Run(filtered.workflows)
 	if err != nil {

--- a/cmd/detest/run.go
+++ b/cmd/detest/run.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "strings"
+	"fmt"
+	"os"
+	"strings"
 
-    "github.com/bgricker/detest/internal/config"
-    "github.com/bgricker/detest/internal/output"
-    "github.com/bgricker/detest/internal/runner"
-    "github.com/spf13/cobra"
+	"github.com/bgricker/detest/internal/config"
+	"github.com/bgricker/detest/internal/output"
+	"github.com/bgricker/detest/internal/runner"
+	"github.com/spf13/cobra"
 )
 
 func newRunCmd() *cobra.Command {
@@ -35,17 +35,18 @@ func runExecute(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-    allowPrivileged := os.Getenv("DETEST_ALLOW_PRIVILEGED") == "1"
+	allowPrivileged := os.Getenv("DETEST_ALLOW_PRIVILEGED") == "1"
 
-    runOpts := runner.Options{
-        Root:      root,
-        Stdout:    cmd.OutOrStdout(),
-        Stderr:    cmd.ErrOrStderr(),
-        Verbose:   cfg.Verbose,
-        DryRun:    cfg.DryRun,
-        TailLines: 20,
-        AllowPrivileged: allowPrivileged,
-    }
+	runOpts := runner.Options{
+		Root:               root,
+		Stdout:             cmd.OutOrStdout(),
+		Stderr:             cmd.ErrOrStderr(),
+		Verbose:            cfg.Verbose,
+		DryRun:             cfg.DryRun,
+		TailLines:          20,
+		AllowPrivileged:    allowPrivileged,
+		PrivilegedPatterns: append([]string{}, cfg.PrivilegedCommandPatterns...),
+	}
 	execRunner := runner.New(runOpts)
 	results, summary, err := execRunner.Run(filtered.workflows)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,8 @@ type Config struct {
 	Verbose bool   `yaml:"verbose"`
 	Format  string `yaml:"format"`
 
-	Warn WarnConfig `yaml:"warn"`
+	Warn                      WarnConfig `yaml:"warn"`
+	PrivilegedCommandPatterns []string   `yaml:"privileged_command_patterns"`
 }
 
 // WarnConfig controls additional warning behaviour.
@@ -91,6 +92,9 @@ func merge(base, override Config) Config {
 	}
 	if len(override.SkipSteps) > 0 {
 		out.SkipSteps = append([]string{}, override.SkipSteps...)
+	}
+	if len(override.PrivilegedCommandPatterns) > 0 {
+		out.PrivilegedCommandPatterns = append([]string{}, override.PrivilegedCommandPatterns...)
 	}
 	if override.Format != "" {
 		out.Format = override.Format

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,9 @@ func Default() Config {
 	return Config{
 		Provider: ProviderAuto,
 		Format:   FormatPretty,
+		Warn: WarnConfig{
+			VersionMismatch: true,
+		},
 	}
 }
 

--- a/internal/output/pretty.go
+++ b/internal/output/pretty.go
@@ -90,6 +90,9 @@ func (p *PrettyRenderer) RenderResults(results []report.StepResult, summary repo
 		if res.Status == "failed" && res.Stderr != "" {
 			fmt.Fprintf(&buffer, "      stderr: %s\n", indent(res.Stderr, "      "))
 		}
+		if res.Status == "skipped" && res.Stderr != "" {
+			fmt.Fprintf(&buffer, "      note: %s\n", indent(res.Stderr, "      "))
+		}
 		if res.DryRun {
 			fmt.Fprintf(&buffer, "      command: %s\n", res.StepRun)
 		}

--- a/internal/version/detect.go
+++ b/internal/version/detect.go
@@ -1,0 +1,79 @@
+package version
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// Info captures a language version installed on the system.
+type Info struct {
+	Name    string
+	Version string
+}
+
+var (
+	rubyRegex = regexp.MustCompile(`(?i)ruby\s+(\d+\.\d+(?:\.\d+)?)`)
+	nodeRegex = regexp.MustCompile(`(?i)v?(\d+\.\d+(?:\.\d+)?)`)
+)
+
+// DetectRuby returns the system Ruby version by calling `ruby -v`.
+func DetectRuby() (Info, error) {
+	out, err := runCommand("ruby", "-v")
+	if err != nil {
+		return Info{}, err
+	}
+	match := rubyRegex.FindStringSubmatch(out)
+	if len(match) < 2 {
+		return Info{}, fmt.Errorf("unable to parse ruby version from %q", out)
+	}
+	return Info{Name: "ruby", Version: match[1]}, nil
+}
+
+// DetectNode returns the system Node.js version by calling `node -v`.
+func DetectNode() (Info, error) {
+	out, err := runCommand("node", "-v")
+	if err != nil {
+		return Info{}, err
+	}
+	match := nodeRegex.FindStringSubmatch(out)
+	if len(match) < 2 {
+		return Info{}, fmt.Errorf("unable to parse node version from %q", out)
+	}
+	return Info{Name: "node", Version: match[1]}, nil
+}
+
+func runCommand(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = nil
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// CompareMajorMinor compares major.minor portions of two semver-like versions.
+func CompareMajorMinor(desired, actual string) bool {
+	d := semverPrefix(desired)
+	a := semverPrefix(actual)
+	return d == "" || a == "" || strings.EqualFold(d, a)
+}
+
+func semverPrefix(version string) string {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return fmt.Sprintf("%s.%s", parts[0], parts[1])
+}
+
+// Missing reports whether executing the command returns a not-found error.
+func Missing(cmdErr error) bool {
+	return errors.Is(cmdErr, exec.ErrNotFound)
+}

--- a/internal/version/detect.go
+++ b/internal/version/detect.go
@@ -62,7 +62,10 @@ func runCommand(name string, args ...string) (string, error) {
 func CompareMajorMinor(desired, actual string) bool {
 	d := semverPrefix(desired)
 	a := semverPrefix(actual)
-	return d == "" || a == "" || strings.EqualFold(d, a)
+	if d == "" || a == "" {
+		return false
+	}
+	return strings.EqualFold(d, a)
 }
 
 func semverPrefix(version string) string {

--- a/internal/version/detect_test.go
+++ b/internal/version/detect_test.go
@@ -1,0 +1,39 @@
+package version
+
+import "testing"
+
+func TestSemverPrefix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"2.6.9", "2.6"},
+		{"14.17.0", "14.17"},
+		{"", ""},
+		{"1", ""},
+	}
+	for _, c := range cases {
+		if got := semverPrefix(c.in); got != c.want {
+			t.Fatalf("semverPrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestCompareMajorMinor(t *testing.T) {
+	tests := []struct {
+		desired string
+		actual  string
+		match   bool
+	}{
+		{"2.6.9", "2.6.3", true},
+		{"2.6", "2.6.3", true},
+		{"14.17", "14.18.1", false},
+		{"", "14.18.1", true},
+		{"14.17", "", true},
+	}
+	for _, tt := range tests {
+		if got := CompareMajorMinor(tt.desired, tt.actual); got != tt.match {
+			t.Fatalf("CompareMajorMinor(%q,%q)=%v want %v", tt.desired, tt.actual, got, tt.match)
+		}
+	}
+}

--- a/internal/version/detect_test.go
+++ b/internal/version/detect_test.go
@@ -28,8 +28,8 @@ func TestCompareMajorMinor(t *testing.T) {
 		{"2.6.9", "2.6.3", true},
 		{"2.6", "2.6.3", true},
 		{"14.17", "14.18.1", false},
-		{"", "14.18.1", true},
-		{"14.17", "", true},
+		{"", "14.18.1", false},
+		{"14.17", "", false},
 	}
 	for _, tt := range tests {
 		if got := CompareMajorMinor(tt.desired, tt.actual); got != tt.match {


### PR DESCRIPTION
### **User description**
- default on CLI config now enables version mismatch warnings and README covers the new DETEST_ALLOW_PRIVILEGED toggle
  - auto-detect the repo’s .ruby-version/.node-version, inspect local interpreters, and append provider warnings when the major.minor differs or the runtime is missing
  - introduce internal/version helper to detect Ruby/Node versions and compare semver prefixes with unit coverage
  - runner now skips sudo/apt-get style commands on non-Linux hosts (unless DETEST_ALLOW_PRIVILEGED=1) and annotates the skipped steps in the pretty report
  - normalize bundler “missing” failures into actionable messages and add tests for the new skip/hint behavior; docs updated accordingly
  - all tests refreshed (`go test ./...`)


___

### **PR Type**
Enhancement


___

### **Description**
- Add version mismatch warnings for Ruby/Node interpreters

- Skip privileged commands on non-Linux hosts automatically

- Improve error messages for missing bundler dependencies

- Enable version checks by default in CLI configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version Files"] --> B["Version Detection"]
  B --> C["Warning Generation"]
  D["Step Execution"] --> E["Privilege Check"]
  E --> F["Skip or Execute"]
  G["Error Output"] --> H["Simplified Messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>pipeline.go</strong><dd><code>Add version detection and warning generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-15ecc60849275912dc5fd10fd744380ce075c95ae7900240012f02e48b28d598">+69/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>run.go</strong><dd><code>Add privileged command environment variable support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-25a92c232f772359ed6ccaa4965c3342194ac8dbabe3e6d2715a2c4cbb213bbd">+18/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pretty.go</strong><dd><code>Add note display for skipped steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ce">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exec.go</strong><dd><code>Skip privileged commands and simplify error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-c2ff3b451be7b59a62d516f9a5494b4465865fb42d143434bbc348c791e0d1d5">+59/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>detect.go</strong><dd><code>Create version detection utility for Ruby/Node</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-8a08a2b634b6d6b3d890bcc91452380a3a86eafb1e1d11b9881d04d474c9d8a8">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.go</strong><dd><code>Enable version mismatch warnings by default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cd">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>exec_test.go</strong><dd><code>Add tests for privilege skipping and error simplification</code></dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-c68b621f19599f66cc422521d34eea077ea2b529460949a12289fefab22dfd4a">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>detect_test.go</strong><dd><code>Add unit tests for version comparison logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-725a6358a2822ae10a206b5c8545cada36bae485b035366320fdfda6bd77f137">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document privileged command toggle and version warnings</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BGRicker/detest/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

