### PR TITLE
Fix critical bug: privileged command patterns not loading when configis empty

### DIFF
--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -54,7 +54,7 @@ func New(opts Options) *Runner {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
-	if opts.PrivilegedPatterns == nil {
+	if opts.PrivilegedPatterns == nil || len(opts.PrivilegedPatterns) == 0 {
 		opts.PrivilegedPatterns = DefaultPrivilegedPatterns()
 	}
 	opts.PrivilegedPatterns = append([]string{}, opts.PrivilegedPatterns...)


### PR DESCRIPTION
The privileged command detection was not working because when cfg.PrivilegedCommandPatterns was empty (default case), it created an empty slice [] instead of nil. The New() function only checked for nil, so DefaultPrivilegedPatterns() was never called.

This caused sudo commands to execute and prompt for passwords instead of being skipped.

Fixed by changing the condition to check for both nil and empty slice:
- Before: if opts.PrivilegedPatterns == nil
- After:  if opts.PrivilegedPatterns == nil || len(opts.PrivilegedPatterns) == 0

Now privileged commands are properly skipped by default on all platforms, preventing accidental sudo password prompts while still allowing override with DETEST_ALLOW_PRIVILEGED=1 when absolutely necessary.