### PR TITLE
Fix environment inheritance for shell command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ $ DETEST_ALLOW_PRIVILEGED=1 detest run
 
 Flags such as `--workflow`, `--job`, `--only-step`, and `--skip-step` accept multiple values and support substring or `/regex/` matches. When no workflows are provided, Detest automatically loads `.github/workflows/*.yml`/`*.yaml` in lexicographic order. Execution stops with a non-zero exit code if any step fails, but all remaining steps continue to run so you see the full picture.
 
+## Environment Support
+
+Detest automatically inherits your shell environment and supports version managers:
+
+- **asdf**: Automatically sources `asdf.sh` (or `asdf.fish` for fish shell) to ensure correct Ruby, Node, Python versions
+- **rbenv**: Works with your existing rbenv setup
+- **Shell compatibility**: Supports bash, zsh, ksh, sh, and fish shells
+- **Environment variables**: Merges workflow → job → step environment variables
+- **Working directories**: Respects `working-directory` settings from workflows
+
 ## Configuration
 
 An optional `.detest.yml` can provide defaults for the CLI. Command-line flags always win over config values.
@@ -62,6 +72,9 @@ privileged_command_patterns:
 - ✅ Sequential execution with env/shell/working-directory resolution
 - ✅ Pretty & JSON reporters with per-step duration/excerpts
 - ✅ Dry-run, verbose streaming, job/step filters, repeatable `--workflow`
+- ✅ Environment inheritance with asdf/rbenv support
+- ✅ Cross-shell compatibility (bash, zsh, ksh, sh, fish)
+- ✅ Privileged command detection and skipping
 - 🚧 Upcoming: richer runtime pre-flight checks, additional CI providers, matrix & services support
   - Version mismatch warnings are enabled by default; set `warn.version_mismatch: false` to silence them.
 

--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -193,9 +193,16 @@ func commandArgs(shellSpec string, script string, env []string) ([]string, error
 		// This ensures tools like asdf, rbenv, etc. work properly
 		asdfInit := ""
 		if asdfDir := getEnvValue(env, "ASDF_DIR"); asdfDir != "" {
-			asdfInit = fmt.Sprintf("source %s/asdf.sh && ", asdfDir)
-		} else if _, err := os.Stat("/Users/benricker/.asdf/asdf.sh"); err == nil {
-			asdfInit = "source /Users/benricker/.asdf/asdf.sh && "
+			// Use filepath.Join for safe path construction and validate the path
+			asdfPath := filepath.Join(asdfDir, "asdf.sh")
+			if _, err := os.Stat(asdfPath); err == nil {
+				asdfInit = fmt.Sprintf("source %s && ", asdfPath)
+			}
+		} else if home, err := os.UserHomeDir(); err == nil {
+			asdfPath := filepath.Join(home, ".asdf", "asdf.sh")
+			if _, err := os.Stat(asdfPath); err == nil {
+				asdfInit = fmt.Sprintf("source %s && ", asdfPath)
+			}
 		}
 		return []string{"bash", "-l", "-c", asdfInit + script}, nil
 	}

--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -192,7 +192,7 @@ func commandArgs(shellSpec string, script string, env []string) ([]string, error
 		// Use bash with login shell and source asdf if available
 		// This ensures tools like asdf, rbenv, etc. work properly
 		asdfInit := getAsdfInit(env, "bash")
-		return []string{"bash", "-l", "-c", asdfInit + script}, nil
+		return []string{"bash", "-l", "-c", asdfInit + " " + script}, nil
 	}
 
 	fields := strings.Fields(shellSpec)
@@ -204,13 +204,13 @@ func commandArgs(shellSpec string, script string, env []string) ([]string, error
 	case "bash", "zsh", "ksh", "fish":
 		// These shells support login flag, use it for proper environment inheritance
 		asdfInit := getAsdfInit(env, base)
-		args = append(args, "-l", "-c", asdfInit + script)
+		args = append(args, "-l", "-c", asdfInit + " " + script)
 		return append([]string{shell}, args...), nil
 	case "sh":
 		// sh might be dash or another shell that doesn't support -l, use only -c
 		// Also use POSIX-compliant asdf initialization
 		asdfInit := getAsdfInit(env, "sh")
-		args = append(args, "-c", asdfInit + script)
+		args = append(args, "-c", asdfInit + " " + script)
 		return append([]string{shell}, args...), nil
 	case "cmd", "cmd.exe":
 		args = append(args, "/C", script)
@@ -363,7 +363,6 @@ func getEnvValue(env []string, key string) string {
 func getAsdfInit(env []string, shellBase string) string {
 	// Determine asdf script path
 	var asdfPath string
-	
 	// Check ASDF_DIR from environment first
 	if asdfDir := getEnvValue(env, "ASDF_DIR"); asdfDir != "" {
 		// Use filepath.Join for safe path construction and validate the path
@@ -372,7 +371,6 @@ func getAsdfInit(env []string, shellBase string) string {
 			asdfPath = ""
 		}
 	}
-	
 	// Fallback to HOME from environment, then os.UserHomeDir()
 	if asdfPath == "" {
 		home := getEnvValue(env, "HOME")
@@ -381,7 +379,6 @@ func getAsdfInit(env []string, shellBase string) string {
 				home = homeDir
 			}
 		}
-		
 		if home != "" {
 			asdfPath = filepath.Join(home, ".asdf", "asdf.sh")
 			if _, err := os.Stat(asdfPath); err != nil {
@@ -389,11 +386,9 @@ func getAsdfInit(env []string, shellBase string) string {
 			}
 		}
 	}
-	
 	if asdfPath == "" {
 		return ""
 	}
-	
 	// Return shell-specific initialization string
 	switch shellBase {
 	case "bash", "zsh":

--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -399,10 +399,10 @@ func getAsdfInit(env []string, shellBase string) string {
 		// fish uses different syntax and file extension
 		fishPath := strings.TrimSuffix(asdfPath, ".sh") + ".fish"
 		if _, err := os.Stat(fishPath); err == nil {
-			return fmt.Sprintf("source %q; and ", fishPath)
+			return fmt.Sprintf("source %q; ", fishPath)
 		}
 		// Fallback to bash script if fish version doesn't exist
-		return fmt.Sprintf("source %q; and ", asdfPath)
+		return fmt.Sprintf("source %q; ", asdfPath)
 	default:
 		// For unknown shells, skip asdf initialization to avoid errors
 		return ""


### PR DESCRIPTION
- Use login shells (bash -l -c) to ensure proper environment inheritance
- Automatically source asdf.sh when available to support version managers
- Fix Ruby/bundler environment issues that prevented CI commands from running
- Pass environment through command execution chain for proper inheritance

This resolves issues where detest couldn't run Ruby commands due to using system Ruby instead of asdf-managed Ruby versions.