### PR TITLE
Ux overhaul

### DIFF
--- a/cmd/detest/run.go
+++ b/cmd/detest/run.go
@@ -47,6 +47,13 @@ func runExecute(cmd *cobra.Command, args []string) error {
 		AllowPrivileged:    allowPrivileged,
 		PrivilegedPatterns: append([]string{}, cfg.PrivilegedCommandPatterns...),
 	}
+
+	// Enable streaming for pretty format when not verbose
+	if strings.ToLower(cfg.Format) == config.FormatPretty && !cfg.Verbose && !cfg.DryRun {
+		runOpts.Streaming = true
+		runOpts.StreamingRenderer = output.NewStreamingPretty(cmd.OutOrStdout())
+	}
+
 	execRunner := runner.New(runOpts)
 	results, summary, err := execRunner.Run(filtered.workflows)
 	if err != nil {
@@ -62,9 +69,12 @@ func runExecute(cmd *cobra.Command, args []string) error {
 
 	switch strings.ToLower(cfg.Format) {
 	case config.FormatPretty:
-		renderer := output.NewPretty(cmd.OutOrStdout())
-		if err := renderer.RenderResults(results, summary); err != nil {
-			return err
+		// Only use pretty renderer if not streaming
+		if !runOpts.Streaming {
+			renderer := output.NewPretty(cmd.OutOrStdout())
+			if err := renderer.RenderResults(results, summary); err != nil {
+				return err
+			}
 		}
 		if len(warnings) > 0 {
 			for _, msg := range warnings {

--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -162,6 +162,11 @@ func (r *Runner) runStreaming(workflows []provider.Workflow) ([]report.StepResul
 					return nil, summary, err
 				}
 			}
+			
+			// Complete job with streaming update
+			if err := r.opts.StreamingRenderer.CompleteJob(); err != nil {
+				return nil, summary, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces a new streaming output mode for the "pretty" format, allowing users to see real-time updates of workflow execution similar to GitHub Actions. The implementation adds a `StreamingPrettyRenderer` and integrates it into the runner, providing a more interactive and informative user experience when not running in verbose or dry-run modes.

**Streaming Output Enhancements:**

- Added a `StreamingPrettyRenderer` in `internal/output/pretty.go` that implements a new `StreamingRenderer` interface for real-time step and job updates during workflow execution, including clear job/step status indicators and error details. [[1]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR14-R57) [[2]](diffhunk://#diff-a915f8ee09f4e978a46506d00ea0e5797feca1f2912ade69704694de4d6036ceR143-R250)
- Updated the runner (`internal/runner/exec.go`) to support streaming mode via new `Streaming` and `StreamingRenderer` options, and implemented `runStreaming` to execute workflows with live updates. [[1]](diffhunk://#diff-c2ff3b451be7b59a62d516f9a5494b4465865fb42d143434bbc348c791e0d1d5R17) [[2]](diffhunk://#diff-c2ff3b451be7b59a62d516f9a5494b4465865fb42d143434bbc348c791e0d1d5R34-R35) [[3]](diffhunk://#diff-c2ff3b451be7b59a62d516f9a5494b4465865fb42d143434bbc348c791e0d1d5R69-R184)

**Command Integration:**

- Modified `cmd/detest/run.go` to enable streaming when the output format is "pretty" and neither verbose nor dry-run modes are active. The command now selects between streaming and batch rendering as appropriate. [[1]](diffhunk://#diff-25a92c232f772359ed6ccaa4965c3342194ac8dbabe3e6d2715a2c4cbb213bbdR50-R56) [[2]](diffhunk://#diff-25a92c232f772359ed6ccaa4965c3342194ac8dbabe3e6d2715a2c4cbb213bbdR72-R78)

These changes provide a more dynamic and user-friendly output for workflow execution, making it easier to track progress and diagnose failures as they happen.